### PR TITLE
shouldn't it be /etc/passwd instead of /etc/group?

### DIFF
--- a/tasks/users-update.yml
+++ b/tasks/users-update.yml
@@ -2,7 +2,7 @@
 
 - name: "Get list of current users to update"
   shell:
-    'getent group | cut -f1 -d:'
+    'getent passwd | cut -f1 -d:'
   register:
     users_present
   changed_when:


### PR DESCRIPTION
I understand that it probably worked well for all these years dues to creation of likewise named user groups -- but shouldn't it be an "honest" user list just in case? It is a role, after all :)